### PR TITLE
fix: use arguments JSON notation for CMD

### DIFF
--- a/docker/fusionauth/fusionauth-app/Dockerfile
+++ b/docker/fusionauth/fusionauth-app/Dockerfile
@@ -49,4 +49,4 @@ RUN export FUSIONAUTH_VERSION=1.14.1 \
 
 ###### Start FusionAuth App #########################################
 USER fusionauth
-CMD /usr/local/fusionauth/fusionauth-app/apache-tomcat/bin/catalina.sh run
+CMD ["/usr/local/fusionauth/fusionauth-app/apache-tomcat/bin/catalina.sh", "run"]


### PR DESCRIPTION
Ref: https://github.com/hadolint/hadolint/wiki/DL3025

In a nutshell, a container can't be stopped properly without this change.

Note: You may add Hadolint to your CI jobs, this tool is very helpful!