### PR TITLE
allow extraPaths for alb actions, and potentially other things

### DIFF
--- a/helm/fusionauth/templates/ingress.yaml
+++ b/helm/fusionauth/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "fusionauth.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
+{{- $extraPaths := .Values.ingress.extraPaths -}}
 apiVersion: {{ include "fusionauth.ingressApiVersion" . }}
 kind: Ingress
 metadata:
@@ -30,6 +31,9 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
+        {{- if $extraPaths }}
+{{ $extraPaths | toYaml | indent 10 }}
+        {{- end }}
         {{- range $ingressPaths }}
           - path: {{ . }}
             backend:

--- a/helm/fusionauth/values.yaml
+++ b/helm/fusionauth/values.yaml
@@ -89,6 +89,8 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   paths: []
+  # Define complete path objects, will be inserted before regular paths. Can be useful for things like ALB Ingress Controller actions
+  extraPaths: []
   hosts:
     - chart-example.local
   tls: []


### PR DESCRIPTION
This allows setting arbitrary path objects that can do things like match to alb ingress controller for redirects, etc.