### PR TITLE
Added Caddy as reverse proxy.

### DIFF
--- a/docker/fusionauth/Caddyfile
+++ b/docker/fusionauth/Caddyfile
@@ -1,0 +1,10 @@
+# replace :80 with your domain name to get automatic https via LetsEncrypt
+# Default http. Add your domain to serve only https (recommended)
+# don't forget to set your DNS first as Caddy will automatically validate and create certificates for you; 
+# login.myawesomedomain.com {
+#   reverse_proxy fusionauth:9011
+# }
+
+:80 {
+  reverse_proxy fusionauth:9011
+}

--- a/docker/fusionauth/docker-compose.yml
+++ b/docker/fusionauth/docker-compose.yml
@@ -39,8 +39,6 @@ services:
       FUSIONAUTH_APP_RUNTIME_MODE: development
       FUSIONAUTH_APP_URL: http://fusionauth:9011
       SEARCH_TYPE: database
-
-
     networks:
      - db
     restart: unless-stopped
@@ -48,7 +46,20 @@ services:
       - 9011:9011
     volumes:
       - fa_config:/usr/local/fusionauth/config
-
+  caddy:
+    image: caddy
+    depends_on:
+    - fusionauth
+    restart: unless-stopped
+    ports:
+    - "80:80"
+    - "443:443"
+    volumes:
+    - ./Caddyfile:/etc/caddy/Caddyfile
+    - caddy_data:/data
+    - caddy_config:/config
+    networks:
+    - db      
 networks:
   db:
     driver: bridge
@@ -56,3 +67,5 @@ networks:
 volumes:
   db_data:
   fa_config:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
By using a reverse proxy like Caddy, docker users may automatically publish their system on 443 without dealing with SSL certificates and all. Thanks to Caddy's auto integration with Letsencrypt. [Click here for more info on their auto-ssl](https://caddyserver.com/docs/automatic-https)