### PR TITLE
Sync up envt var names.

### DIFF
--- a/docker/fusionauth/docker-compose.yml
+++ b/docker/fusionauth/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       DATABASE_ROOT_PASSWORD: ${POSTGRES_PASSWORD}
       # Prior to version 1.19.0, use this deprecated name
       # DATABASE_USER: ${DATABASE_USER}
-      DATABASE_USERNAME: ${DATABASE_USER}
+      DATABASE_USERNAME: ${DATABASE_USERNAME}
       DATABASE_PASSWORD: ${DATABASE_PASSWORD}
       # Prior to version 1.19.0, use this deprecated names
       # FUSIONAUTH_MEMORY: ${FUSIONAUTH_MEMORY}


### PR DESCRIPTION
Previously the DATABASE_USERNAME which was received by docker was pulled from the DATABASE_USER env var, which is the oldschool name. Also part of a dock sync up: https://github.com/FusionAuth/fusionauth-site/pull/304