### PR TITLE
No need for the search container name

### DIFF
--- a/docker/fusionauth/docker-compose.yml
+++ b/docker/fusionauth/docker-compose.yml
@@ -20,7 +20,6 @@ services:
 
   search:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
-    container_name: search
     environment:
       cluster.name: fusionauth
       bootstrap.memory_lock: "true"


### PR DESCRIPTION
We don't need to hardcode the search container name.

If you want to run more than one fusionauth instance at a time, it collides, I think.

I've removed it in my docker compose examples and FusionAuth starts up fine.