### PR TITLE
disable GC logging when running FusionAuth via container

### DIFF
--- a/docker/fusionauth/fusionauth-app/Dockerfile
+++ b/docker/fusionauth/fusionauth-app/Dockerfile
@@ -103,6 +103,7 @@ LABEL maintainer="FusionAuth <dev@fusionauth.io>"
 EXPOSE 9011
 USER fusionauth
 ENV FUSIONAUTH_USE_GLOBAL_JAVA=1
+ENV FUSIONAUTH_DISABLE_GC_LOG=1
 ENV JAVA_HOME=/opt/openjdk
 ENV PATH=$PATH:$JAVA_HOME/bin
 CMD ["/usr/local/fusionauth/fusionauth-app/bin/start.sh"]


### PR DESCRIPTION
**Issue**: 
https://github.com/FusionAuth/fusionauth-issues/issues/2392

**Summary**: 
FusionAuth 1.47.0 fails to start in a container because the log directory used by the new gc logging doesn't exist.

**Solution**:
Add ENV variable FUSIONAUTH_DISABLE_GC_LOG=1 in Dockerfile 

**Linked PR**:
https://github.com/FusionAuth/fusionauth-app/pull/289
