### PR TITLE
add curl

### DIFF
--- a/docker/fusionauth/fusionauth-app/Dockerfile
+++ b/docker/fusionauth/fusionauth-app/Dockerfile
@@ -2,11 +2,11 @@
 # FusionAuth App Dockerfile
 #
 # Build:
-#   > docker pull ubuntu:jammy
+#   > docker pull ubuntu:lunar
 #   > docker buildx build --platform=linux/arm64 -t fusionauth/fusionauth-app:1.47.1 .
 #   > docker buildx build --platform=linux/arm64 -t fusionauth/fusionauth-app:latest .
 #
-# Note: Substiture your target platform architecture. The above example is targetting a 64-bit ARM platform.
+# Note: Substitute your target platform architecture. The above example is targetting a 64-bit ARM platform.
 #       To target an Intel based platform use --platform=linux/amd64.
 #
 # Run:
@@ -66,7 +66,6 @@ RUN case "${BUILDPLATFORM}" in \
         exit 1;\
         ;;\
     esac \
-    && apt-get update \
     && apt-get install -y curl unzip \
     && mkdir -p /tmp/openjdk \
     && mkdir -p /tmp/build/openjdk \
@@ -88,7 +87,10 @@ RUN case "${BUILDPLATFORM}" in \
 
 ###### Use Ubuntu latest and only copy in what we need to reduce the layer size ###################
 FROM ubuntu:jammy
-RUN useradd -d /usr/local/fusionauth -U fusionauth
+RUN apt-get update \
+    && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists \
+    && useradd -d /usr/local/fusionauth -U fusionauth
 COPY --chown=fusionauth:fusionauth --from=build /opt/openjdk /opt/openjdk
 COPY --chown=fusionauth:fusionauth --from=build /usr/local/fusionauth /usr/local/fusionauth
 

--- a/docker/fusionauth/fusionauth-app/Dockerfile
+++ b/docker/fusionauth/fusionauth-app/Dockerfile
@@ -2,7 +2,7 @@
 # FusionAuth App Dockerfile
 #
 # Build:
-#   > docker pull ubuntu:lunar
+#   > docker pull ubuntu:jammy
 #   > docker buildx build --platform=linux/arm64 -t fusionauth/fusionauth-app:1.47.1 .
 #   > docker buildx build --platform=linux/arm64 -t fusionauth/fusionauth-app:latest .
 #


### PR DESCRIPTION
### Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/2272

### Related
- https://github.com/FusionAuth/fusionauth-app/pull/296

### Summary
- Add `curl` to the image. This will add `7.03MB` of additional un-compressed size to the image.

Here is the diff of images layers:

```
docker image history  fusionauth/fusionauth-app:dev
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
3e488493ee42   5 minutes ago   CMD ["/usr/local/fusionauth/fusionauth-app/b…   0B        buildkit.dockerfile.v0
<missing>      5 minutes ago   ENV PATH=/usr/local/sbin:/usr/local/bin:/usr…   0B        buildkit.dockerfile.v0
<missing>      5 minutes ago   ENV JAVA_HOME=/opt/openjdk                      0B        buildkit.dockerfile.v0
<missing>      5 minutes ago   ENV FUSIONAUTH_USE_GLOBAL_JAVA=1                0B        buildkit.dockerfile.v0
<missing>      5 minutes ago   USER fusionauth                                 0B        buildkit.dockerfile.v0
<missing>      5 minutes ago   EXPOSE map[9011/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      5 minutes ago   LABEL maintainer=FusionAuth <dev@fusionauth.…   0B        buildkit.dockerfile.v0
<missing>      5 minutes ago   LABEL description=Create an image running Fu…   0B        buildkit.dockerfile.v0
<missing>      5 minutes ago   RUN /bin/sh -c mkdir -p /usr/local/fusionaut…   0B        buildkit.dockerfile.v0
<missing>      5 minutes ago   COPY /usr/local/fusionauth /usr/local/fusion…   117MB     buildkit.dockerfile.v0
<missing>      5 minutes ago   COPY /opt/openjdk /opt/openjdk # buildkit       91.2MB    buildkit.dockerfile.v0

// This is the new part of the image which is 7.03 MB of additional non-compressed size. 
<missing>      5 minutes ago   RUN /bin/sh -c apt-get update     && apt-get…   7.03MB    buildkit.dockerfile.v0

<missing>      5 weeks ago     /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>      5 weeks ago     /bin/sh -c #(nop) ADD file:262490f82459c1463…   69.2MB
<missing>      5 weeks ago     /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
<missing>      5 weeks ago     /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
<missing>      5 weeks ago     /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B
<missing>      5 weeks ago     /bin/sh -c #(nop)  ARG RELEASE                  0B
```

```
> docker image history  fusionauth/fusionauth-app:latest
IMAGE          CREATED       CREATED BY                                      SIZE      COMMENT
f9444c823118   7 days ago    CMD ["/usr/local/fusionauth/fusionauth-app/b…   0B        buildkit.dockerfile.v0
<missing>      7 days ago    ENV PATH=/usr/local/sbin:/usr/local/bin:/usr…   0B        buildkit.dockerfile.v0
<missing>      7 days ago    ENV JAVA_HOME=/opt/openjdk                      0B        buildkit.dockerfile.v0
<missing>      7 days ago    ENV FUSIONAUTH_USE_GLOBAL_JAVA=1                0B        buildkit.dockerfile.v0
<missing>      7 days ago    USER fusionauth                                 0B        buildkit.dockerfile.v0
<missing>      7 days ago    EXPOSE map[9011/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      7 days ago    LABEL maintainer=FusionAuth <dev@fusionauth.…   0B        buildkit.dockerfile.v0
<missing>      7 days ago    LABEL description=Create an image running Fu…   0B        buildkit.dockerfile.v0
<missing>      7 days ago    RUN /bin/sh -c mkdir -p /usr/local/fusionaut…   11B       buildkit.dockerfile.v0
<missing>      7 days ago    COPY /usr/local/fusionauth /usr/local/fusion…   117MB     buildkit.dockerfile.v0
<missing>      7 days ago    COPY /opt/openjdk /opt/openjdk # buildkit       90.4MB    buildkit.dockerfile.v0
<missing>      7 days ago    RUN /bin/sh -c useradd -d /usr/local/fusiona…   333kB     buildkit.dockerfile.v0
<missing>      5 weeks ago   /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>      5 weeks ago   /bin/sh -c #(nop) ADD file:262490f82459c1463…   69.2MB
<missing>      5 weeks ago   /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
<missing>      5 weeks ago   /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
<missing>      5 weeks ago   /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B
<missing>      5 weeks ago   /bin/sh -c #(nop)  ARG RELEASE                  0B
```