### PR TITLE
Adding a `getit` script for easier Docker files download

### DIFF
--- a/docker/fusionauth/getit
+++ b/docker/fusionauth/getit
@@ -21,39 +21,51 @@
 #
 
 # Useful colors
-COLOR_RESET="\e[0m"
-COLOR_RED="\e[31m"
-COLOR_GREEN="\e[32m"
-COLOR_YELLOW="\e[33m"
-COLOR_CYAN="\e[36m"
+if test -t 1; then
+    COLOR_RESET="\e[0m"
+    COLOR_RED="\e[31m"
+    COLOR_GREEN="\e[32m"
+    COLOR_YELLOW="\e[33m"
+    COLOR_CYAN="\e[36m"
+else
+    COLOR_RESET=""
+    COLOR_RED=""
+    COLOR_GREEN=""
+    COLOR_YELLOW=""
+    COLOR_CYAN=""
+fi
 
 # Displays help menu
 display_help() {
   printf "%bDescription:%b\n" "$COLOR_YELLOW" "$COLOR_RESET"
-  printf "  Downloads necessary files to start a FusionAuth instance\n\n"
+  printf "  Downloads %b.env%b and %bdocker-compose.yml%b files to\n" "$COLOR_CYAN" "$COLOR_RESET" "$COLOR_CYAN" "$COLOR_RESET"
+  printf "  start a FusionAuth instance with Docker Compose\n\n"
 
   printf "%bUsage:%b\n" "$COLOR_YELLOW" "$COLOR_RESET"
   printf "  %b$0%b [options]%b\n\n" "$COLOR_GREEN" "$COLOR_YELLOW" "$COLOR_RESET"
 
   printf "%bOptions:%b\n" "$COLOR_YELLOW" "$COLOR_RESET"
-  printf "  %b-k, --kickstart%b   Downloads files to be used with Kickstart\n" "$COLOR_GREEN" "$COLOR_RESET"
+  printf "  %b--download%b            Downloads standard .env and docker-compose.yml files\n" "$COLOR_GREEN" "$COLOR_RESET"
+  printf "  %b--download-kickstart%b  Downloads files to be used with Kickstart\n" "$COLOR_GREEN" "$COLOR_RESET"
 }
 
 # Files to download
 case "$1" in
-"-k" | "--kickstart")
-  DOCKER_COMPOSE_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-template/master/docker-compose.yml"
-  ENV_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-template/master/.env"
+"--download")
+  DOCKER_COMPOSE_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/docker-compose.yml"
+  ENV_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/.env"
+  printf "Downloading files\n"
   ;;
 
-"-h" | "--help")
-  display_help
-  exit 1
+"--download-kickstart")
+  DOCKER_COMPOSE_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-template/master/docker-compose.yml"
+  ENV_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-template/master/.env"
+  printf "Downloading files with Kickstart capabilities\n"
   ;;
 
 **)
-  DOCKER_COMPOSE_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/docker-compose.yml"
-  ENV_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/.env"
+  display_help
+  exit 1
   ;;
 esac
 

--- a/docker/fusionauth/getit
+++ b/docker/fusionauth/getit
@@ -17,7 +17,7 @@
 #
 # You can install FusionAuth by running:
 #
-# curl -s https://fusionauth.io/getit | sh -
+# curl -s https://fusionauth.io/getit | sh -s - --download
 #
 
 # Useful colors

--- a/docker/fusionauth/getit
+++ b/docker/fusionauth/getit
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# Copyright (c) 2018-2023, FusionAuth, All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+#
+# You can install FusionAuth by running:
+#
+# curl -s https://fusionauth.io/getit | sh -
+#
+
+# Useful colors
+COLOR_RESET="\e[0m"
+COLOR_RED="\e[31m"
+COLOR_GREEN="\e[32m"
+COLOR_YELLOW="\e[33m"
+COLOR_CYAN="\e[36m"
+
+# Displays help menu
+display_help() {
+  printf "%bDescription:%b\n" "$COLOR_YELLOW" "$COLOR_RESET"
+  printf "  Downloads necessary files to start a FusionAuth instance\n\n"
+
+  printf "%bUsage:%b\n" "$COLOR_YELLOW" "$COLOR_RESET"
+  printf "  %b$0%b [options]%b\n\n" "$COLOR_GREEN" "$COLOR_YELLOW" "$COLOR_RESET"
+
+  printf "%bOptions:%b\n" "$COLOR_YELLOW" "$COLOR_RESET"
+  printf "  %b-k, --kickstart%b   Downloads files to be used with Kickstart\n" "$COLOR_GREEN" "$COLOR_RESET"
+}
+
+# Files to download
+case "$1" in
+"-k" | "--kickstart")
+  DOCKER_COMPOSE_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-template/master/docker-compose.yml"
+  ENV_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-template/master/.env"
+  ;;
+
+"-h" | "--help")
+  display_help
+  exit 1
+  ;;
+
+**)
+  DOCKER_COMPOSE_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/docker-compose.yml"
+  ENV_FILE="https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/.env"
+  ;;
+esac
+
+# Downloading files
+download() {
+  printf "[ %b•%b ] Downloading %b%s%b..." "$COLOR_CYAN" "$COLOR_RESET" "$COLOR_YELLOW" "$1" "$COLOR_RESET"
+  curlError=$(curl --no-progress-meter --fail -o "$1" "$2" 2>&1)
+  # shellcheck disable=SC2181
+  if [ $? -ne 0 ]; then
+    printf "\r[ %b×%b ] Downloading %b%s%b %bFAILED%b\n" "$COLOR_RED" "$COLOR_RESET" "$COLOR_YELLOW" "$1" "$COLOR_RESET" "$COLOR_RED" "$COLOR_RESET"
+    printf "[ %b×%b ] %bError: %s%b\n" "$COLOR_RED" "$COLOR_RESET" "$COLOR_RED" "$curlError" "$COLOR_RESET"
+    exit 1
+  fi
+  printf "\r[ %b✔%b ] Downloading %b%s%b\n" "$COLOR_GREEN" "$COLOR_RESET" "$COLOR_YELLOW" "$1" "$COLOR_RESET"
+}
+
+download "docker-compose.yml" "$DOCKER_COMPOSE_FILE"
+download ".env" "$ENV_FILE"
+
+printf "[ %b✔%b ] %bAll files downloaded successfully%b\n" "$COLOR_GREEN" "$COLOR_RESET" "$COLOR_GREEN" "$COLOR_RESET"
+printf "[ %b✔%b ] %bYou can start your FusionAuth instance by running %bdocker compose up -d%b\n" "$COLOR_GREEN" "$COLOR_RESET" "$COLOR_RESET" "$COLOR_CYAN" "$COLOR_RESET"


### PR DESCRIPTION
# Description

This adds a `getit` script to simplify downloading Docker files to start an instance. Instead of running:

```shell
curl -o docker-compose.yml https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/docker-compose.yml
curl -o .env https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/.env
```

One would only need to do:

```shell
curl -s https://fusionauth.io/getit | sh -s -- --download
```

## Secondary scenario

I know we only have to [download those 2 files](https://fusionauth.io/docs/v1/tech/installation-guide/docker) right now, but we've been copying them into every quickstart demo app. So if we'd ever want to update those files, we'd have to replace them in every single repo. In this scenario, we'd just need to add a step to the quickstart article with the command below to download files with Kickstart settings:

```shell
curl -s https://fusionauth.io/getit | sh -s -- --download-kickstart         
```

# Screenshot

This is how it looks like: 

![Usage sample](https://github.com/vcampitelli/fusionauth-getit/assets/1877191/cedca7be-bcd7-4cd3-bee2-366ab5fbaf1c)

# Redirect

@mooreds said we could add this a redirect script to our website to have it on `fusionauth.io/getit`. Can we do that?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205100644092785