### PR TITLE
remove scripting and bump to 1.49

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 
 import java.nio.charset.StandardCharsets
 
-project(group: "io.fusionauth", name: "fusionauth-containers", version: "1.48.2", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-containers", version: "1.49.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/docker/fusionauth/fusionauth-app/Dockerfile
+++ b/docker/fusionauth/fusionauth-app/Dockerfile
@@ -21,8 +21,8 @@
 FROM --platform=$BUILDPLATFORM ubuntu:jammy as build
 
 ARG BUILDPLATFORM
-ARG FUSIONAUTH_VERSION=1.48.2
-ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.security.jgss,java.security.sasl,java.scripting,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.dynalink,jdk.jcmd,jdk.jdi,jdk.localedata,jdk.jpackage,jdk.unsupported,jdk.zipfs
+ARG FUSIONAUTH_VERSION=1.49.0
+ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.security.jgss,java.security.sasl,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.dynalink,jdk.jcmd,jdk.jdi,jdk.localedata,jdk.jpackage,jdk.unsupported,jdk.zipfs
 ARG TARGETPLATFORM
 ARG TARGETARCH
 RUN printf "Building on ${BUILDPLATFORM} for ${TARGETPLATFORM} (${TARGETARCH})."


### PR DESCRIPTION
In 1.49.0 FusionAuth is removing the Nashorn javascript engine and no longer needs the `java.scripting` module included in the runtime


Related PR
- https://github.com/FusionAuth/fusionauth-app/pull/347
- https://github.com/FusionAuth/fusionauth-developer/pull/9