### PR TITLE
Adding healthcheck to the app container

### DIFF
--- a/docker/fusionauth/docker-compose.yml
+++ b/docker/fusionauth/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       SEARCH_SERVERS: http://search:9200
       SEARCH_TYPE: elasticsearch
     healthcheck:
-      test: curl --silent --fail http://localhost:9011 -o /dev/null -w "%{http_code}"
+      test: curl --silent --fail http://localhost:9011/api/status -o /dev/null -w "%{http_code}"
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker/fusionauth/docker-compose.yml
+++ b/docker/fusionauth/docker-compose.yml
@@ -65,6 +65,11 @@ services:
       FUSIONAUTH_APP_URL: http://fusionauth:9011
       SEARCH_SERVERS: http://search:9200
       SEARCH_TYPE: elasticsearch
+    healthcheck:
+      test: curl --silent --fail http://localhost:9011 -o /dev/null -w "%{http_code}"
+      interval: 5s
+      timeout: 5s
+      retries: 5
     networks:
       - db_net
       - search_net


### PR DESCRIPTION
Adding a simple `curl` healthcheck to the FusionAuth app container (both `db` and `search` containers have one already).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206834540104677