### PR TITLE
In prep for Prime MVC 4.22.8/BaseJWT changes, need this module

### DIFF
--- a/docker/fusionauth/fusionauth-app/Dockerfile
+++ b/docker/fusionauth/fusionauth-app/Dockerfile
@@ -22,7 +22,7 @@ FROM --platform=$BUILDPLATFORM ubuntu:jammy as build
 
 ARG BUILDPLATFORM
 ARG FUSIONAUTH_VERSION=1.50.1
-ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.security.jgss,java.security.sasl,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.dynalink,jdk.jcmd,jdk.jdi,jdk.localedata,jdk.jpackage,jdk.unsupported,jdk.zipfs
+ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.net.http,java.rmi,java.security.jgss,java.security.sasl,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.dynalink,jdk.jcmd,jdk.jdi,jdk.localedata,jdk.jpackage,jdk.unsupported,jdk.zipfs
 ARG TARGETPLATFORM
 ARG TARGETARCH
 RUN printf "Building on ${BUILDPLATFORM} for ${TARGETPLATFORM} (${TARGETARCH})."


### PR DESCRIPTION
Below Prime MVC PR will use `java.net.HttpClient` instead of Restify and that module is not jlinked in existing images. This will address that.

See

https://github.com/FusionAuth/fusionauth-app/pull/433
https://github.com/prime-framework/prime-mvc/pull/48

Verified I could run a Docker build after this change:

```
brady@Brady-Inversoft-MBP [16:56:56] [~/dev/inversoft/fusionauth/fusionauth-containers/docker/fusionauth/fusionauth-app] [wied03/java_net_http_module]
-> % docker build . -t fa_test_http                                                                            <aws:cleanspeak-old> <region:us-west-2>
[+] Building 111.9s (11/11) FINISHED                                                                                              docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                              0.0s
 => => transferring dockerfile: 5.71kB                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/ubuntu:jammy                                                                                   1.0s
 => [internal] load .dockerignore                                                                                                                 0.0s
 => => transferring context: 2B                                                                                                                   0.0s
 => [build 1/3] FROM docker.io/library/ubuntu:jammy@sha256:6d7b5d3317a71adb5e175640150e44b8b9a9401a7dd394f44840626aff9fa94d                       0.0s
 => => resolve docker.io/library/ubuntu:jammy@sha256:6d7b5d3317a71adb5e175640150e44b8b9a9401a7dd394f44840626aff9fa94d                             0.0s
 => => sha256:984f7324c44c67df577958e874e7e438c67ff7bb6562129129405da98a388518 424B / 424B                                                        0.0s
 => => sha256:23ae71f2bc601e0e4b21b06dbc9a01fefa28569901196469921b293d716779b7 2.31kB / 2.31kB                                                    0.0s
 => => sha256:6d7b5d3317a71adb5e175640150e44b8b9a9401a7dd394f44840626aff9fa94d 1.13kB / 1.13kB                                                    0.0s
 => [build 2/3] RUN printf "Building on linux/arm64 for linux/arm64 (arm64)."                                                                     0.1s
 => [stage-1 2/5] RUN apt-get update     && apt-get -y install --no-install-recommends curl     && apt-get -y upgrade     && apt-get -y clean    11.7s
 => [build 3/3] RUN case "linux/arm64" in     linux/arm64)        BUILD_JAVA_SUM="eefd3cf3b3dd47ff269fa5b5c10b5e096b163f4e9c1810023abdbc00dc6c  110.1s
 => [stage-1 3/5] COPY --chown=fusionauth:fusionauth --from=build /opt/openjdk /opt/openjdk                                                       0.1s 
 => [stage-1 4/5] COPY --chown=fusionauth:fusionauth --from=build /usr/local/fusionauth /usr/local/fusionauth                                     0.1s 
 => [stage-1 5/5] RUN mkdir -p /usr/local/fusionauth/logs   && touch /usr/local/fusionauth/logs/fusionauth-app.log   && ln -sf /dev/stdout /usr/  0.1s 
 => exporting to image                                                                                                                            0.2s 
 => => exporting layers                                                                                                                           0.2s 
 => => writing image sha256:8f6e294a4e0f6be09c5f827a7fce30c8ac7b91bb6803f1619facad5e184e42b9                                                      0.0s 
 => => naming to docker.io/library/fa_test_http                                        
```