### PR TITLE
Add `java.net.http` to the Dockerfile

### DIFF
--- a/docker/fusionauth/fusionauth-app/Dockerfile
+++ b/docker/fusionauth/fusionauth-app/Dockerfile
@@ -18,11 +18,11 @@
 #
 
 ###### Setup the java and fusionauth-app base #####################################################
-FROM --platform=$BUILDPLATFORM ubuntu:jammy as build
+FROM --platform=$BUILDPLATFORM ubuntu:jammy AS build
 
 ARG BUILDPLATFORM
 ARG FUSIONAUTH_VERSION=1.51.1
-ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.security.jgss,java.security.sasl,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.dynalink,jdk.jcmd,jdk.jdi,jdk.localedata,jdk.jpackage,jdk.unsupported,jdk.zipfs
+ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.net.http,java.rmi,java.security.jgss,java.security.sasl,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.dynalink,jdk.jcmd,jdk.jdi,jdk.localedata,jdk.jpackage,jdk.unsupported,jdk.zipfs
 ARG TARGETPLATFORM
 ARG TARGETARCH
 RUN printf "Building on ${BUILDPLATFORM} for ${TARGETPLATFORM} (${TARGETARCH})."


### PR DESCRIPTION
### Issue:
- https://github.com/FusionAuth/fusionauth-issues/issues/2726

### Problem:
A change to `prime-mvc` now requires the `java.net.http` module.

### Solution:
1. Add `java.net.http` in support of new version of prime-mvc.
2. Correct case on 'as' to 'AS' per Docker build warning.

### Related PR:
- https://github.com/FusionAuth/fusionauth-app/pull/493

### Linked PRs:
- https://github.com/prime-framework/prime-mvc/pull/48
- https://github.com/CleanSpeak/cleanspeak-containers/pull/4/files
- https://github.com/CleanSpeak/cleanspeak-app/pull/6/files#diff-6ef52ae3e926ea992c266bfce3c3fe4881594f5293effab85304173bd0ae65b9
- https://github.com/FusionAuth/fusionauth-developer/pull/22