### PR TITLE
Docker compose config with kickstart and no search

### DIFF
--- a/docker/fusionauth/.env
+++ b/docker/fusionauth/.env
@@ -5,3 +5,4 @@ FUSIONAUTH_APP_RUNTIME_MODE=development
 OPENSEARCH_JAVA_OPTS="-Xms512m -Xmx512m"
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
+FUSIONAUTH_APP_KICKSTART_FILE=/usr/local/fusionauth/kickstart/kickstart.json

--- a/docker/fusionauth/docker-compose.kickstart-nosearch.yml
+++ b/docker/fusionauth/docker-compose.kickstart-nosearch.yml
@@ -1,0 +1,54 @@
+services:
+  fa_db:
+    image: postgres:16.0-bookworm
+    container_name: fa_db
+    ports:
+      - "5432:5432"
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - db_net
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  fa:
+    image: fusionauth/fusionauth-app:latest
+    container_name: fa
+    depends_on:
+      fa_db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: jdbc:postgresql://fa_db:5432/fusionauth
+      DATABASE_ROOT_USERNAME: ${POSTGRES_USER}
+      DATABASE_ROOT_PASSWORD: ${POSTGRES_PASSWORD}
+      DATABASE_USERNAME: ${DATABASE_USERNAME}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+      FUSIONAUTH_APP_MEMORY: ${FUSIONAUTH_APP_MEMORY}
+      FUSIONAUTH_APP_RUNTIME_MODE: ${FUSIONAUTH_APP_RUNTIME_MODE}
+      FUSIONAUTH_APP_URL: http://fa:9011
+      SEARCH_TYPE: database
+      FUSIONAUTH_APP_KICKSTART_FILE: ${FUSIONAUTH_APP_KICKSTART_FILE}
+    networks:
+      - db_net
+    ports:
+      - 9011:9011
+    volumes:
+      - fusionauth_config:/usr/local/fusionauth/config
+      - ./kickstart:/usr/local/fusionauth/kickstart
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+networks:
+  db_net:
+    driver: bridge
+
+volumes:
+  db_data:
+  fusionauth_config:


### PR DESCRIPTION
- Light weight configuration used in guides to quickly spin up FusionAuth locally with configurations from a kickstart https://github.com/FusionAuth/fusionauth-example-kickstart/pull/3 for demonstration with no need for search