### PR TITLE
Old 'arm' JDK is not available anymore

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -47,7 +47,7 @@ jobs:
           context: .
           file: ./docker/fusionauth/fusionauth-app/Dockerfile
           build-args: FUSIONAUTH_VERSION=${{ env.FUSIONAUTH_VERSION }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ env.FUSIONAUTH_TAGS }}
 

--- a/docker/fusionauth/release-trigger
+++ b/docker/fusionauth/release-trigger
@@ -1,3 +1,4 @@
 version=1.53.0
 latestVersion=true
 tagSuffix=
+# Touch


### PR DESCRIPTION
Breaks container release process - This is a follow up fix to https://github.com/FusionAuth/fusionauth-containers/pull/106