### PR TITLE
Forcing lowercase string value for security and memory lock settings in docker-compose

### DIFF
--- a/docker/fusionauth/docker-compose.yml
+++ b/docker/fusionauth/docker-compose.yml
@@ -61,8 +61,8 @@ services:
       cluster.name: fusionauth
       discovery.type: single-node
       node.name: search
-      plugins.security.disabled: true
-      bootstrap.memory_lock: true
+      plugins.security.disabled: "true"
+      bootstrap.memory_lock: "true"
       OPENSEARCH_JAVA_OPTS: ${OPENSEARCH_JAVA_OPTS}
     healthcheck:
       interval: 10s


### PR DESCRIPTION
for Win11 compatibility.

Fixes #136.

Disclaimer: haven't tested with Linux yet, nor with Docker compose.