### PR TITLE
append debian revision to JDK shim version

### DIFF
--- a/docker/fusionauth/fusionauth-app/Dockerfile
+++ b/docker/fusionauth/fusionauth-app/Dockerfile
@@ -61,7 +61,7 @@ RUN --mount=type=bind,target=/ctx apt-get update \
        fi \
     && mkdir -p /usr/local/fusionauth/fusionauth-app \
     && unzip -nq /tmp/fusionauth-app.zip -d /usr/local/fusionauth \
-    && JAVA_DEB_VERSION=$(echo "${JAVA_VERSION}" | sed 's/_/+/') \
+    && JAVA_DEB_VERSION="$(echo "${JAVA_VERSION}" | sed 's/_/+/')-99" \
     && DEB_TARGETARCH="${TARGETARCH}" \
     && if [ "${TARGETARCH}" = "ppc64le" ]; then DEB_TARGETARCH="ppc64el"; fi \
     && mkdir -p /tmp/jdk-shim/DEBIAN \


### PR DESCRIPTION
## Problem

the nightly dependency scan fails with 8 false positive JDK CVEs. the dpkg shim registers version 21.0.11+10 but trivy vuln DB expects ubuntu debian package version 21.0.11+10-1~24.04.2. in dpkg comparison, no revision sorts lower than any revision — so the shim always looks older than the fix.

## Solution

append -99 as the debian revision to the shim version string. this sorts higher than any real ubuntu package revision for the same upstream release. temurin tracks upstream security patches, so the debian revision is packaging metadata only.

relates to ENG-2593